### PR TITLE
Add woff2 webfont type

### DIFF
--- a/README.md
+++ b/README.md
@@ -329,6 +329,7 @@ If you don't control versioning with filename-based cache busting, consider lowe
     ExpiresByType application/rss+xml                   "access plus 1 hour"
 
   # Web fonts
+    ExpiresByType application/font-woff2                "access plus 1 month"
     ExpiresByType application/font-woff                 "access plus 1 month"
     ExpiresByType application/vnd.ms-fontobject         "access plus 1 month"
     ExpiresByType application/x-font-ttf                "access plus 1 month"
@@ -388,7 +389,7 @@ Sometimes you want to force the browser to display some content instead of downl
 CDN-served webfonts might not work in Firefox or IE due to [CORS](https://en.wikipedia.org/wiki/Cross-origin_resource_sharing). The following snippet from [alrra](https://github.com/h5bp/server-configs-apache/issues/32) should make it happen.
 ``` apacheconf
 <IfModule mod_headers.c>
-    <FilesMatch "\.(eot|otf|ttc|ttf|woff)$">
+    <FilesMatch "\.(eot|otf|ttc|ttf|woff|woff2)$">
         Header set Access-Control-Allow-Origin "*"
     </FilesMatch>
 </IfModule>


### PR DESCRIPTION
woff2 is supported by Chrome & Opera: [Can I use WOFF2](http://caniuse.com/#feat=woff2)
Also enabled in FontAwesome since 4.3.0: [FortAwesome/Font-Awesome#4261](https://github.com/FortAwesome/Font-Awesome/issues/4261)
Learn more about the WOFF2:
[Basics about WOFF 2.0](https://gist.github.com/sergejmueller/cf6b4f2133bcb3e2f64a)
[W3C specification](http://www.w3.org/TR/WOFF2/)