### PR TITLE
Remove Trailing Slash from Arbitrary Paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ What we are doing here is mostly collecting useful snippets from all over the in
     - [Force HTTPS Behind a Proxy](#force-https-behind-a-proxy)
     - [Force Trailing Slash](#force-trailing-slash)
     - [Remove Trailing Slash](#remove-trailing-slash)
-    - [Remove Trailing Slash from Arbitary Paths](#remove-trailing-slash-from-arbitary-paths)
+    - [Remove Trailing Slash from Arbitary Paths](#remove-trailing-slash-from-arbitrary-paths)
     - [Redirect a Single Page](#redirect-a-single-page)
     - [Alias a Single Directory](#alias-a-single-directory)
     - [Alias Paths to Script](#alias-paths-to-script)
@@ -121,7 +121,7 @@ RewriteCond %{REQUEST_FILENAME} !-d
 RewriteRule ^(.*)/$ /$1 [R=301,L]
 ```
 
-### Remove Trailing Slash from Arbitary Paths
+### Remove Trailing Slash from Arbitrary Paths
 This snippet will redirect paths ending in slashes to their non-slash-terminated counterparts (except for actual directories).
 E.g., `http://www.example.com/blog/` -> `http://www.example.com/blog`
 This is important for SEO, since it is [recommended to have a "canonical URL" for every page](http://overit.com/blog/canonical-urls).

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ What we are doing here is mostly collecting useful snippets from all over the in
     - [Force HTTPS Behind a Proxy](#force-https-behind-a-proxy)
     - [Force Trailing Slash](#force-trailing-slash)
     - [Remove Trailing Slash](#remove-trailing-slash)
+    - [Remove Trailing Slash from Arbitary Paths](#remove-trailing-slash-from-arbitary-paths)
     - [Redirect a Single Page](#redirect-a-single-page)
     - [Alias a Single Directory](#alias-a-single-directory)
     - [Alias Paths to Script](#alias-paths-to-script)
@@ -119,6 +120,18 @@ RewriteRule ^(.+[^/])$ %{REQUEST_URI}/ [R=301,L]
 RewriteCond %{REQUEST_FILENAME} !-d
 RewriteRule ^(.*)/$ /$1 [R=301,L]
 ```
+
+### Remove Trailing Slash from Arbitary Paths
+This snippet will redirect paths ending in slashes to their non-slash-terminated counterparts (except for actual directories).
+E.g., `http://www.example.com/blog/` -> `http://www.example.com/blog`
+This is important for SEO, since it is [recommended to have a "canonical URL" for every page](http://overit.com/blog/canonical-urls).
+``` apacheconf
+RewriteCond %{REQUEST_FILENAME} !-d
+RewriteCond %{REQUEST_URI} (.+)/$
+RewriteRule ^ %1 [L,R=301]
+```
+[Source](https://stackoverflow.com/questions/21417263/htaccess-add-remove-trailing-slash-from-url)
+
 ### Redirect a Single Page
 ``` apacheconf
 Redirect 301 /oldpage.html http://www.example.com/newpage.html

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ What we are doing here is mostly collecting useful snippets from all over the in
     - [Force HTTPS Behind a Proxy](#force-https-behind-a-proxy)
     - [Force Trailing Slash](#force-trailing-slash)
     - [Remove Trailing Slash](#remove-trailing-slash)
-    - [Remove Trailing Slash from Arbitary Paths](#remove-trailing-slash-from-arbitrary-paths)
+    - [Remove Trailing Slash from Arbitrary Paths](#remove-trailing-slash-from-arbitrary-paths)
     - [Redirect a Single Page](#redirect-a-single-page)
     - [Alias a Single Directory](#alias-a-single-directory)
     - [Alias Paths to Script](#alias-paths-to-script)


### PR DESCRIPTION
This allows you to remove the trailing slash from URIs that point to files in subdirectories. The current "trailing slash" solution only works for files in the top-level directory.